### PR TITLE
feat: add universal router address in hemi sepolia

### DIFF
--- a/.github/workflows/test-forge.yml
+++ b/.github/workflows/test-forge.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   tests:
+    # Disable tests for fork
+    if: false
     name: Unit tests
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-hardhat.yml
+++ b/.github/workflows/test-hardhat.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   tests:
+    # Disable tests for fork
+    if: false
     name: Hardhat tests
 
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@uniswap/universal-router-sdk",
+  "name": "@hemilabs/universal-router-sdk",
   "version": "1.8.2",
   "description": "sdk for integrating with the Universal Router contracts",
   "main": "dist/index.js",
@@ -51,7 +51,7 @@
   "dependencies": {
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.9.0",
-    "@uniswap/sdk-core": "^4.2.0",
+    "@hemilabs/sdk-core": "4.2.0-beta.2",
     "@uniswap/universal-router": "1.6.0",
     "@uniswap/v2-sdk": "^4.2.0",
     "@uniswap/v3-sdk": "^3.11.0",
@@ -60,10 +60,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Uniswap/universal-router-sdk.git"
+    "url": "git+https://github.com/hemilabs/universal-router-sdk.git"
   },
   "bugs": {
-    "url": "https://github.com/Uniswap/universal-router-sdk/issues"
+    "url": "https://github.com/hemilabs/universal-router-sdk/issues"
   },
-  "homepage": "https://github.com/Uniswap/universal-router-sdk#readme"
+  "homepage": "https://github.com/hemilabs/universal-router-sdk#readme"
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -104,6 +104,12 @@ const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
     weth: '0x4300000000000000000000000000000000000004',
     creationBlock: 1116444,
   },
+  [743_111]: {
+    router: '0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD',
+    weth: '0x0C8aFD1b58aa2A5bAd2414B861D8A7fF898eDC3A',
+    // Needs to be updated once the contract is deployed on Hemi
+    creationBlock: 201254,
+  },
 }
 
 export const UNIVERSAL_ROUTER_ADDRESS = (chainId: number): string => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,10 @@
     "noUnusedParameters": true,
     "lib": ["esnext.string"],
     "typeRoots": ["./typechain", "./node_modules/@types"],
-    "types": ["@types/mocha", "node"]
+    "types": ["@types/mocha", "node"],
+    "paths": {
+      "@uniswap/sdk-core": ["./node_modules/@hemilabs/sdk-core"]
+    }
   },
   "include": ["src", "test"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1298,6 +1298,19 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@hemilabs/sdk-core@4.2.0-beta.2":
+  version "4.2.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@hemilabs/sdk-core/-/sdk-core-4.2.0-beta.2.tgz#7968c495fe10dcc1ea50a799dd02bf8c2f5ec6e4"
+  integrity sha512-b9ZbmLxWo5gKH4SQX/mjZkNgDucaQtq3sGVuPw05pGAeejmoHSG6EEtOQElupGcswhTSb9LohPV/SnpvGy+peQ==
+  dependencies:
+    "@ethersproject/address" "^5.0.2"
+    "@ethersproject/bignumber" "^5.7.0"
+    big.js "^5.2.2"
+    decimal.js-light "^2.5.0"
+    jsbi "^3.1.4"
+    tiny-invariant "^1.1.0"
+    toformat "^2.0.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz"


### PR DESCRIPTION
This PR adds the Universal Router address to Hemi Sepolia. The contract is not deployed yet, but according to Rohit and Max the address is deterministic and will be the same. Only the creation block needs to be updated once deployed

