### PR TITLE
feat: Update universal router address on Hemi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/universal-router-sdk",
-  "version": "1.8.2",
+  "version": "1.8.2-beta.2",
   "description": "sdk for integrating with the Universal Router contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -105,10 +105,10 @@ const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
     creationBlock: 1116444,
   },
   [743_111]: {
-    router: '0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD',
+    router: '0xA18019E62f266C2E17e33398448e4105324e0d0F',
     weth: '0x0C8aFD1b58aa2A5bAd2414B861D8A7fF898eDC3A',
     // Needs to be updated once the contract is deployed on Hemi
-    creationBlock: 201254,
+    creationBlock: 344561,
   },
 }
 


### PR DESCRIPTION
Universal router address was incorrect. Address deployed [here](https://testnet.explorer.hemi.network/address/0xA18019E62f266C2E17e33398448e4105324e0d0F?tab=txs)